### PR TITLE
Provide a `NoOpCacheManager` when `spring.cache.type=none` is set

### DIFF
--- a/src/main/java/com/mycompany/myapp/config/CacheConfiguration.java
+++ b/src/main/java/com/mycompany/myapp/config/CacheConfiguration.java
@@ -8,12 +8,14 @@ import org.hibernate.cache.jcache.ConfigSettings;
 import io.github.jhipster.config.JHipsterProperties;
 
 import org.springframework.boot.autoconfigure.cache.JCacheManagerCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.*;
 
 @Configuration
 @EnableCaching
+@ConditionalOnExpression("'${spring.cache.type}'!='none'")
 public class CacheConfiguration {
 
     private final javax.cache.configuration.Configuration<Object, Object> jcacheConfiguration;

--- a/src/test/java/com/mycompany/myapp/config/NoCacheConfiguration.java
+++ b/src/test/java/com/mycompany/myapp/config/NoCacheConfiguration.java
@@ -1,0 +1,19 @@
+package com.mycompany.myapp.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+@ConditionalOnExpression("'${spring.cache.type}'=='none'")
+public class NoCacheConfiguration {
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new NoOpCacheManager();
+    }
+}

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -16,6 +16,8 @@
 spring:
   application:
     name: tester
+  cache:
+    type: none
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
     url: jdbc:h2:mem:tester;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MULTI_THREADED=FALSE


### PR DESCRIPTION
When `spring.cache.type=none` is set in application properties, provide a `NoOpCacheManager` so that it can be injected into UserService that requires it for clearing caches.